### PR TITLE
fix: disable bypass_platform_safety_checks_on_user_schedule_enabled when hotpatching_enabled is true

### DIFF
--- a/r-vm.tf
+++ b/r-vm.tf
@@ -104,7 +104,7 @@ resource "azurerm_windows_virtual_machine" "main" {
   patch_mode                                             = var.patch_mode
   patch_assessment_mode                                  = var.patch_mode == "AutomaticByPlatform" ? var.patch_mode : "ImageDefault"
   hotpatching_enabled                                    = var.hotpatching_enabled
-  bypass_platform_safety_checks_on_user_schedule_enabled = var.patch_mode == "AutomaticByPlatform"
+  bypass_platform_safety_checks_on_user_schedule_enabled = var.hotpatching_enabled ? false : var.patch_mode == "AutomaticByPlatform"
   reboot_setting                                         = var.patch_mode == "AutomaticByPlatform" ? var.patching_reboot_setting : null
 }
 


### PR DESCRIPTION
Apparently, this additional limitation is not well documented,
but the Azure platform is explicit about it:

```
Error: creating Windows Virtual Machine (...) performing CreateOrUpdate:
unexpected status 400 (400 Bad Request) with error: InvalidParameter:
  Hotpatch updates require platform safety checks.
  The 'BypassPlatformSafetyChecksOnUserSchedule' flag must be
  set to false to enable hotpatching.
```

------

Would it be possible to create the `legacy/v7` branch, see https://github.com/claranet/terraform-azurerm-aks-light/issues/14#issuecomment-2665326686?
I would like to port to v7 this fix and #3, if that would be accepted.
