### PR TITLE
refactor(tagging): ♻️ replace outdated tagging module with `azapi_resource_action`

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ data "azuread_group" "vm_users_group" {
 
 | Name | Version |
 |------|---------|
+| azapi | ~> 2.0 |
 | azurecaf | ~> 1.2, >= 1.2.22 |
 | azurerm | ~> 3.108 |
 | null | ~> 3.0 |
@@ -276,12 +277,12 @@ data "azuread_group" "vm_users_group" {
 | Name | Source | Version |
 |------|--------|---------|
 | azure\_region | claranet/regions/azurerm | ~> 7.2.0 |
-| vm\_os\_disk\_tagging | claranet/tagging/azurerm | 6.0.2 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [azapi_resource_action.main](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource_action) | resource |
 | [azurerm_backup_protected_vm.backup](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/backup_protected_vm) | resource |
 | [azurerm_key_vault_access_policy.vm](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_certificate.winrm_certificate](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_certificate) | resource |
@@ -370,7 +371,6 @@ data "azuread_group" "vm_users_group" {
 | os\_disk\_caching | Specifies the caching requirements for the OS Disk. | `string` | `"ReadWrite"` | no |
 | os\_disk\_custom\_name | Custom name for OS disk. Generated if not set. | `string` | `null` | no |
 | os\_disk\_extra\_tags | Extra tags to set on the OS disk. | `map(string)` | `{}` | no |
-| os\_disk\_overwrite\_tags | True to overwrite existing OS disk tags instead of merging. | `bool` | `false` | no |
 | os\_disk\_size\_gb | Specifies the size of the OS disk in gigabytes. | `string` | `null` | no |
 | os\_disk\_storage\_account\_type | The Type of Storage Account which should back this the Internal OS Disk. Possible values are `Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS`, `StandardSSD_ZRS` and `Premium_ZRS`. | `string` | `"Premium_ZRS"` | no |
 | os\_disk\_tagging\_enabled | Should OS disk tagging be enabled? Defaults to `true`. | `bool` | `true` | no |

--- a/r-vm.tf
+++ b/r-vm.tf
@@ -131,15 +131,16 @@ resource "null_resource" "winrm_connection_test" {
   }
 }
 
-module "vm_os_disk_tagging" {
-  source  = "claranet/tagging/azurerm"
-  version = "6.0.2"
+resource "azapi_resource_action" "main" {
+  count = var.os_disk_tagging_enabled ? 1 : 0
 
-  nb_resources = var.os_disk_tagging_enabled ? 1 : 0
-  resource_ids = [data.azurerm_managed_disk.vm_os_disk.id]
-  behavior     = var.os_disk_overwrite_tags ? "overwrite" : "merge"
+  type        = "Microsoft.Compute/disks@2022-03-02"
+  resource_id = data.azurerm_managed_disk.vm_os_disk.id
+  method      = "PATCH"
 
-  tags = merge(local.default_tags, var.extra_tags, var.os_disk_extra_tags)
+  body = {
+    tags = merge(local.default_tags, var.extra_tags, var.os_disk_extra_tags)
+  }
 }
 
 resource "azurerm_managed_disk" "disk" {

--- a/variables-tags.tf
+++ b/variables-tags.tf
@@ -39,9 +39,3 @@ variable "extensions_extra_tags" {
   type        = map(string)
   default     = {}
 }
-
-variable "os_disk_overwrite_tags" {
-  description = "True to overwrite existing OS disk tags instead of merging."
-  type        = bool
-  default     = false
-}

--- a/versions.tf
+++ b/versions.tf
@@ -13,5 +13,9 @@ terraform {
       source  = "claranet/azurecaf"
       version = "~> 1.2, >= 1.2.22"
     }
+    azapi = {
+      source  = "azure/azapi"
+      version = "~> 2.0"
+    }
   }
 }


### PR DESCRIPTION
This change essentially ports the tagging method from v8.x
Additionally, remove variable `os_disk_overwrite_tags` as no longer used.
    
Closes #7